### PR TITLE
Feat: added gcp credentials support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [0.1.0] - 2025-01-09
+
+### 🚀 Features
+
+- Added option to pass credentials as dict object
+
 ## [0.0.2] - 2025-01-02
 
 ### 🚀 Features
@@ -27,6 +33,7 @@ All notable changes to this project will be documented in this file.
 
 - Changelog updated
 - Version updated to 0.0.2
+- Changelog updated
 - Changelog updated
 - Changelog updated
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ All notable changes to this project will be documented in this file.
 
 - Added option to pass credentials as dict object
 
+### ⚙️ Miscellaneous Tasks
+
+- Changelog updated
+
 ## [0.0.2] - 2025-01-02
 
 ### 🚀 Features

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,11 @@ dynamic = ["version"]
 license = { file = "LICENSE" }
 classifiers = [
     "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
 ]

--- a/src/web3_google_hsm/__version__.py
+++ b/src/web3_google_hsm/__version__.py
@@ -1,1 +1,1 @@
-VERSION = "0.0.2"
+VERSION = "0.1.0"

--- a/src/web3_google_hsm/accounts/gcp_kms_account.py
+++ b/src/web3_google_hsm/accounts/gcp_kms_account.py
@@ -8,13 +8,14 @@ from eth_account._utils.legacy_transactions import serializable_unsigned_transac
 from eth_account.messages import _hash_eip191_message, encode_defunct  # noqa: PLC2701
 from eth_typing import ChecksumAddress
 from eth_utils import keccak, to_checksum_address
+from google.auth import load_credentials_from_dict
 from google.cloud import kms
 from google.protobuf import duration_pb2  # type: ignore
 from pydantic import BaseModel, Field, PrivateAttr
 from rich.traceback import install
 
 from web3_google_hsm.config import BaseConfig
-from web3_google_hsm.exceptions import ConfigurationError, SignatureError
+from web3_google_hsm.exceptions import SignatureError
 from web3_google_hsm.types.ethereum_types import MSG_HASH_LENGTH, Signature, Transaction
 from web3_google_hsm.utils import convert_der_to_rsv, extract_public_key_bytes
 
@@ -46,15 +47,14 @@ class GCPKmsAccount(BaseModel):
         Raises:
             ValueError: If both config and credentials are provided
         """
-        if config is not None and credentials is not None:
-            msg = "Cannot provide both config and credentials. Use one or neither."
-            raise ConfigurationError(msg)
 
         super().__init__(**data)
 
+        if isinstance(credentials, dict):
+            credentials, _ = load_credentials_from_dict(credentials)
         # Initialize client based on provided auth method
         self._client = (
-            kms.KeyManagementServiceClient(credentials=credentials) if credentials else kms.KeyManagementServiceClient()
+            kms.KeyManagementServiceClient(credentials=credentials) if credentials else kms.KeyManagementServiceClient()  # type: ignore
         )
 
         # Initialize settings if config is provided, otherwise None

--- a/src/web3_google_hsm/exceptions.py
+++ b/src/web3_google_hsm/exceptions.py
@@ -2,3 +2,9 @@ class SignatureError(Exception):
     """
     Raised when there are issues with signing.
     """
+
+
+class ConfigurationError(Exception):
+    """
+    Raised when there are issues with the configuration.
+    """

--- a/tests/integration/accounts/test_gcp_credentials.py
+++ b/tests/integration/accounts/test_gcp_credentials.py
@@ -12,8 +12,8 @@ REQUIRED_ENV_VARS = {
     "GOOGLE_CLOUD_REGION": os.getenv("GOOGLE_CLOUD_REGION"),
     "KEY_RING": os.getenv("KEY_RING"),
     "KEY_NAME": os.getenv("KEY_NAME"),
-    "GCP_CREDENTIALS_STRING": os.getenv("GCP_CREDENTIALS_STRING"),
-    "GCP_CREDENTIALS_STRING": os.getenv("GCP_CREDENTIALS_STRING"),
+    "GCP_ADC_CREDENTIALS_STRING": os.getenv("GCP_ADC_CREDENTIALS_STRING"),
+    "GCP_ADC_CREDENTIALS_STRING": os.getenv("GCP_ADC_CREDENTIALS_STRING"),
 }
 
 # Skip all tests if any required env var is missing
@@ -25,8 +25,8 @@ pytestmark = pytest.mark.skipif(
 
 def test_account_initialization_with_both():
     """Test initializing account with both config and credentials."""
-    # Load credentials from GCP_CREDENTIALS_STRING env var
-    credentials = json.loads(os.environ["GCP_CREDENTIALS_STRING"])
+    # Load credentials from GCP_ADC_CREDENTIALS_STRING env var
+    credentials = json.loads(os.environ["GCP_ADC_CREDENTIALS_STRING"])
 
     # Create config from environment
     config = BaseConfig.from_env()
@@ -73,7 +73,7 @@ def test_fail_account_initialization_with_only_config(monkeypatch):
         "KEY_RING",
         "KEY_NAME",
         "GOOGLE_APPLICATION_CREDENTIALS",
-        "GCP_CREDENTIALS_STRING"
+        "GCP_ADC_CREDENTIALS_STRING"
     ]
 
     for env_var in env_vars_to_clear:
@@ -94,7 +94,7 @@ def test_fail_account_initialization_with_only_credentials(monkeypatch):
 
     for env_var in env_vars_to_clear:
         monkeypatch.delenv(env_var, raising=False)
-    credentials = json.loads(os.environ["GCP_CREDENTIALS_STRING"])
+    credentials = json.loads(os.environ["GCP_ADC_CREDENTIALS_STRING"])
 
     with pytest.raises(ValidationError):
         GCPKmsAccount(credentials=credentials)
@@ -102,7 +102,7 @@ def test_fail_account_initialization_with_only_credentials(monkeypatch):
 def test_key_path_matches_config(monkeypatch):
     """Test that the key path matches the config values."""
     # Load both config and credentials
-    credentials = json.loads(os.environ["GCP_CREDENTIALS_STRING"])
+    credentials = json.loads(os.environ["GCP_ADC_CREDENTIALS_STRING"])
 
     config = BaseConfig.from_env()
     account = GCPKmsAccount(config=config, credentials=credentials)

--- a/tests/integration/accounts/test_gcp_credentials.py
+++ b/tests/integration/accounts/test_gcp_credentials.py
@@ -1,0 +1,114 @@
+import os
+
+from pydantic import ValidationError
+import pytest
+from web3_google_hsm.accounts.gcp_kms_account import GCPKmsAccount
+from web3_google_hsm.config import BaseConfig
+import json
+
+# Define required environment variables
+REQUIRED_ENV_VARS = {
+    "GOOGLE_CLOUD_PROJECT": os.getenv("GOOGLE_CLOUD_PROJECT"),
+    "GOOGLE_CLOUD_REGION": os.getenv("GOOGLE_CLOUD_REGION"),
+    "KEY_RING": os.getenv("KEY_RING"),
+    "KEY_NAME": os.getenv("KEY_NAME"),
+    "GCP_CREDENTIALS_STRING": os.getenv("GCP_CREDENTIALS_STRING"),
+    "GCP_CREDENTIALS_STRING": os.getenv("GCP_CREDENTIALS_STRING"),
+}
+
+# Skip all tests if any required env var is missing
+missing_vars = [k for k, v in REQUIRED_ENV_VARS.items() if not v]
+pytestmark = pytest.mark.skipif(
+    bool(missing_vars),
+    reason=f"Missing required environment variables: {', '.join(missing_vars)}"
+)
+
+def test_account_initialization_with_both():
+    """Test initializing account with both config and credentials."""
+    # Load credentials from GCP_CREDENTIALS_STRING env var
+    credentials = json.loads(os.environ["GCP_CREDENTIALS_STRING"])
+
+    # Create config from environment
+    config = BaseConfig.from_env()
+
+    # Initialize account with both
+    account = GCPKmsAccount(config=config, credentials=credentials)
+
+    # Verify initialization
+    assert account._client is not None
+    assert account._settings is not None
+    assert account.key_path is not None
+    assert account.address.startswith("0x")
+
+    # Test basic functionality
+    message = "Test message"
+    signature = account.sign_message(message)
+    assert signature.v in (27, 28)
+    assert len(signature.r) == 32
+    assert len(signature.s) == 32
+
+def test_account_initialization_with_neither():
+    """Test initializing account with neither config nor credentials (using env vars)."""
+    # Initialize account without explicit config or credentials
+    account = GCPKmsAccount()
+
+    # Verify initialization
+    assert account._client is not None
+    assert account._settings is not None  # Should be created from env
+    assert account.key_path is not None
+    assert account.address.startswith("0x")
+
+    # Test basic functionality
+    message = "Test message"
+    signature = account.sign_message(message)
+    assert signature.v in (27, 28)
+    assert len(signature.r) == 32
+    assert len(signature.s) == 32
+
+def test_fail_account_initialization_with_only_config(monkeypatch):
+    """Test that initializing with only config raises error."""
+    env_vars_to_clear = [
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_CLOUD_REGION",
+        "KEY_RING",
+        "KEY_NAME",
+        "GOOGLE_APPLICATION_CREDENTIALS",
+        "GCP_CREDENTIALS_STRING"
+    ]
+
+    for env_var in env_vars_to_clear:
+        monkeypatch.delenv(env_var, raising=False)
+
+    with pytest.raises(ValidationError):
+        config = BaseConfig.from_env()
+        GCPKmsAccount(config=config)
+
+def test_fail_account_initialization_with_only_credentials(monkeypatch):
+    """Test that initializing with only credentials raises error."""
+    env_vars_to_clear = [
+        "GOOGLE_CLOUD_PROJECT",
+        "GOOGLE_CLOUD_REGION",
+        "KEY_RING",
+        "KEY_NAME",
+    ]
+
+    for env_var in env_vars_to_clear:
+        monkeypatch.delenv(env_var, raising=False)
+    credentials = json.loads(os.environ["GCP_CREDENTIALS_STRING"])
+
+    with pytest.raises(ValidationError):
+        GCPKmsAccount(credentials=credentials)
+
+def test_key_path_matches_config(monkeypatch):
+    """Test that the key path matches the config values."""
+    # Load both config and credentials
+    credentials = json.loads(os.environ["GCP_CREDENTIALS_STRING"])
+
+    config = BaseConfig.from_env()
+    account = GCPKmsAccount(config=config, credentials=credentials)
+
+    # Verify key path contains all the expected components
+    assert config.project_id in account.key_path
+    assert config.location_id in account.key_path
+    assert config.key_ring_id in account.key_path
+    assert config.key_id in account.key_path

--- a/tests/integration/accounts/test_gcp_credentials.py
+++ b/tests/integration/accounts/test_gcp_credentials.py
@@ -13,7 +13,6 @@ REQUIRED_ENV_VARS = {
     "KEY_RING": os.getenv("KEY_RING"),
     "KEY_NAME": os.getenv("KEY_NAME"),
     "GCP_ADC_CREDENTIALS_STRING": os.getenv("GCP_ADC_CREDENTIALS_STRING"),
-    "GCP_ADC_CREDENTIALS_STRING": os.getenv("GCP_ADC_CREDENTIALS_STRING"),
 }
 
 # Skip all tests if any required env var is missing

--- a/tests/integration/accounts/test_gcp_kms_account_integration.py
+++ b/tests/integration/accounts/test_gcp_kms_account_integration.py
@@ -62,7 +62,7 @@ def test_transaction_signing(gcp_account, fund_account, web3):
         gas_price=web3.eth.gas_price,
         gas_limit=21000,
         to="0xa5D3241A1591061F2a4bB69CA0215F66520E67cf",
-        value=web3.to_wei(0.001, "ether"),
+        value=web3.to_wei(0.0001, "ether"),
         data="0x",
         from_=gcp_account.address
     )

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -122,8 +122,20 @@ class TestGenerateCommand:
         assert result.exit_code == 0
         assert "Created Ethereum signing key" in result.stdout
 
-    def test_fail_generate_missing_required_args(self, runner: CliRunner) -> None:
+    def test_fail_generate_missing_required_args(self, runner: CliRunner, monkeypatch) -> None:
         """Test key generation fails when required arguments are missing."""
+        # ? Need to clrear the env vars in order to raise error in the cli
+        env_vars_to_clear = [
+            "GOOGLE_CLOUD_PROJECT",
+            "GOOGLE_CLOUD_REGION",
+            "KEY_RING",
+            "KEY_NAME",
+            "GOOGLE_APPLICATION_CREDENTIALS",
+            "GCP_CREDENTIALS_STRING"
+        ]
+
+        for env_var in env_vars_to_clear:
+            monkeypatch.delenv(env_var, raising=False)
         result = runner.invoke(app, ["generate"])
         assert result.exit_code == 2
         assert "Usage:" in result.stdout

--- a/tests/unit/test_cli.py
+++ b/tests/unit/test_cli.py
@@ -131,7 +131,7 @@ class TestGenerateCommand:
             "KEY_RING",
             "KEY_NAME",
             "GOOGLE_APPLICATION_CREDENTIALS",
-            "GCP_CREDENTIALS_STRING"
+            "GCP_ADC_CREDENTIALS_STRING"
         ]
 
         for env_var in env_vars_to_clear:


### PR DESCRIPTION
Now we can pass Goocle ADC credentials as a string which will be useful to run on workflows especially for read-only systems

## Example
```py
from web3_google_hsm import GCPKmsAccount
import json

data = json.loads('{"account":"","client_id":"1234.apps.googleusercontent.com","client_secret":"AAddseSecretAHHAHA", "refresh_token":"1//RANDOMMMHEHEHEHEHHE-AAddseSecretAHHAHA-AAddseSecretAHHAHA-RANDOMMMHEHEHEHEHHE-RANDOMMMHEHEHEHEHHE","type":"authorized_user","universe_domain":"googleapis.com"}')

account = GCPKmsAccount(credentials=data)
```